### PR TITLE
build: Fix powertools repo name

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,0 @@
-[defaults]
-local_tmp = /tmp/.ansible
-remote_tmp = /tmp/.ansible

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -26,7 +26,7 @@ USER root
 RUN dnf -y update && \
     dnf -y install epel-release 'dnf-command(config-manager)' && \
     dnf module -y enable 'postgresql:10' && \
-    dnf config-manager --set-enabled PowerTools && \
+    dnf config-manager --set-enabled powertools && \
     dnf -y install ansible \
     gcc \
     gcc-c++ \
@@ -126,7 +126,7 @@ RUN dnf -y install \
 RUN dnf -y update && \
     dnf -y install epel-release 'dnf-command(config-manager)' && \
     dnf module -y enable 'postgresql:10' && \
-    dnf config-manager --set-enabled PowerTools && \
+    dnf config-manager --set-enabled powertools && \
     dnf -y install acl \
     ansible \
     bubblewrap \


### PR DESCRIPTION
Fix powertools repo name - old Dockerfile made in Centos 8.1 times had powertools repo with old syntax in name.