### PR TITLE
requirements: Update ansible-cpanel requirements file

### DIFF
--- a/requirements/hostinger/ansible_cpanel.txt
+++ b/requirements/hostinger/ansible_cpanel.txt
@@ -21,5 +21,5 @@ tldextract==3.1.2
 typer==0.4.0
 urllib3==1.26.7
 hvac==0.10.5
-ansible<2.10
-ansible-modules-hashivault==4.6.4
+ansible==4.4.0
+ansible-modules-hashivault==4.6.2


### PR DESCRIPTION
used bit older `ansible-modules-hashivault` due to:
```
    The user requested hvac==0.10.5
    ansible-modules-hashivault 4.6.4 depends on hvac>=0.11.0
```